### PR TITLE
Fix: inconsistent use of caml_strdup

### DIFF
--- a/src/brotli_stubs.c
+++ b/src/brotli_stubs.c
@@ -64,24 +64,24 @@ extern "C" {
       std::copy(output.begin(),
 		output.end(),
 		std::ostreambuf_iterator<char>(FILE));
-      free(save_path);
+      caml_stat_free(save_path);
       FILE.close();
       CAMLreturn(Val_unit);
     }
     case 0: {
-      free(save_path);
+      caml_stat_free(save_path);
       caml_failwith("Decoding error, e.g. corrupt input or no memory");
     }
     case 2: {
-      free(save_path);
+      caml_stat_free(save_path);
       caml_failwith("Partially done, but must be called again with more input");
     }
     case 3: {
-      free(save_path);
+      caml_stat_free(save_path);
       caml_failwith("Partially done, but must be called again with more output");
     }
     default: {
-      free(save_path);
+      caml_stat_free(save_path);
       caml_failwith("Decompression Error");
     }
     }
@@ -169,11 +169,11 @@ extern "C" {
       		std::ostreambuf_iterator<char>(FILE));
       FILE.close();
       delete[] output;
-      free(save_path);
+      caml_stat_free(save_path);
       CAMLreturn(Val_unit);
     } else {
       delete[] output;
-      free(save_path);
+      caml_stat_free(save_path);
       caml_failwith("Compression Error");
     }
   }


### PR DESCRIPTION
Hello. I'm doing a large-scale study of C stub sources on OPAM.

Your library makes use of the undocumented `caml_strdup` function, which currently returns a block that can be passed to `free` from the C standard library. In future, the implementation of this function [may change](https://github.com/ocaml/ocaml/pull/71), making it incompatible with `free` and breaking the code that abused the old undocumented semantics.

Regardless of whether the change of semantics will happen or not, being consistent about such matters should be considered good style.
