### PR TITLE
String_val -> Bytes_val

### DIFF
--- a/src/brotli_stubs.c
+++ b/src/brotli_stubs.c
@@ -114,7 +114,7 @@ CAMLprim value ml_brotli_compress(value part_compress_opt, value params,
   if (result_is_good) {
     size_t compressed_size = output.size() - available_out;
     compressed_string = caml_alloc_string(compressed_size);
-    memmove(String_val(compressed_string), output.data(), compressed_size);
+    memmove(Bytes_val(compressed_string), output.data(), compressed_size);
     CAMLreturn(compressed_string);
   } else {
     caml_failwith("Compression failure");
@@ -161,7 +161,7 @@ CAMLprim value ml_brotli_decompress(value part_decompress_opt,
 
   if ((result == BROTLI_DECODER_SUCCESS) == true) {
     decompressed_string = caml_alloc_string(output.size());
-    memmove(String_val(decompressed_string), &output[0], output.size());
+    memmove(Bytes_val(decompressed_string), &output[0], output.size());
     BrotliDecoderDestroyInstance(dec);
     CAMLreturn(decompressed_string);
   } else {


### PR DESCRIPTION
This fixes compilation errors with CAML_SAFE_STRING enabled:

~~~
File "src/dune", line 5, characters 10-22:
5 |  (c_names brotli_stubs)
              ^^^^^^^^^^^^
In file included from /home/albert/.opam/ocaml-base-compiler.4.14.0/lib/ocaml/caml/alloc.h:24,
                 from brotli_stubs.c:4:
brotli_stubs.c: In function ‘value ml_brotli_compress(value, value, value)’:
/home/albert/.opam/ocaml-base-compiler.4.14.0/lib/ocaml/caml/mlvalues.h:290:24: error: invalid conversion from ‘const void*’ to ‘void*’ [-fpermissive]
  290 | #define String_val(x) ((const char *) Bp_val(x))
      |                       ~^~~~~~~~~~~~~~~~~~~~~~~~~
      |                        |
      |                        const void*
brotli_stubs.c:117:13: note: in expansion of macro ‘String_val’
  117 |     memmove(String_val(compressed_string), output.data(), compressed_size);
      |             ^~~~~~~~~~
In file included from /usr/include/c++/12/cstring:42,
                 from brotli_stubs.c:16:
/usr/include/string.h:47:29: note:   initializing argument 1 of ‘void* memmove(void*, const void*, size_t)’
   47 | extern void *memmove (void *__dest, const void *__src, size_t __n)
      |                       ~~~~~~^~~~~~
~~~