### PR TITLE
Use pkg-config to find libbrotli{enc, dec}

### DIFF
--- a/config/discover.ml
+++ b/config/discover.ml
@@ -1,0 +1,35 @@
+module C = Configurator.V1
+
+let libs = [ "brotlidec"; "brotlienc" ]
+
+let default : C.Pkg_config.package_conf =
+  {
+    libs = "-L/usr/local/lib" :: List.map (fun lib -> "-l" ^ lib) libs;
+    cflags = [ "-I/usr/local/include" ];
+  }
+
+let merge_conf ({ libs; cflags } : C.Pkg_config.package_conf)
+    ({ libs = libs'; cflags = cflags' } : C.Pkg_config.package_conf) :
+    C.Pkg_config.package_conf =
+  {
+    libs = List.concat [ libs; libs' ];
+    cflags = List.concat [ cflags; cflags' ];
+  }
+
+let empty_conf : C.Pkg_config.package_conf = { libs = []; cflags = [] }
+
+let () =
+  C.main ~name:"brotli" (fun c ->
+      let conf =
+        Option.value ~default
+        @@ List.fold_left
+             (fun conf lib ->
+               Option.bind conf @@ fun conf ->
+               Option.bind (C.Pkg_config.get c) @@ fun pc ->
+               Option.bind (C.Pkg_config.query pc ~package:("lib" ^ lib))
+               @@ fun deps -> Some (merge_conf conf deps))
+             (Some empty_conf) libs
+      in
+
+      C.Flags.write_sexp "c_flags.sexp" conf.cflags;
+      C.Flags.write_sexp "c_library_flags.sexp" conf.libs)

--- a/config/dune
+++ b/config/dune
@@ -1,0 +1,3 @@
+(executable
+ (name discover)
+ (libraries dune-configurator))

--- a/src/brotli_stubs.c
+++ b/src/brotli_stubs.c
@@ -143,7 +143,7 @@ CAMLprim value ml_brotli_decompress(value part_decompress_opt,
   }
 
   caml_release_runtime_system();
-  while (result == BROTLI_DECODER_NEEDS_MORE_OUTPUT) {
+  while (result == BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT) {
     result = BrotliDecoderDecompressStream(dec, &available_in, &next_in,
                                            &available_out, &next_out, nullptr);
     size_t buffer_length = 0;
@@ -159,7 +159,7 @@ CAMLprim value ml_brotli_decompress(value part_decompress_opt,
   }
   caml_acquire_runtime_system();
 
-  if ((result == BROTLI_DECODER_SUCCESS) == true) {
+  if ((result == BROTLI_DECODER_RESULT_SUCCESS) == true) {
     decompressed_string = caml_alloc_string(output.size());
     memmove(String_val(decompressed_string), &output[0], output.size());
     BrotliDecoderDestroyInstance(dec);

--- a/src/dune
+++ b/src/dune
@@ -3,6 +3,9 @@
  (public_name brotli)
  (libraries unix)
  (c_names brotli_stubs)
- (c_flags -std=c++11 -x c++ -Wextra -fno-omit-frame-pointer -O2
-   -fno-optimize-sibling-calls -I/usr/local/include)
- (c_library_flags -L/usr/local/lib -lbrotlidec -lbrotlienc -lstdc++))
+ (c_flags -std=c++11 -x c++ -Wextra -fno-omit-frame-pointer -O2 -fno-optimize-sibling-calls (:include c_flags.sexp))
+ (c_library_flags (:include c_library_flags.sexp) -lstdc++))
+
+(rule
+ (targets c_flags.sexp c_library_flags.sexp)
+ (action (run ../config/discover.exe)))


### PR DESCRIPTION
This fixes installation on systems that have libraries or header files in non-standard locations.